### PR TITLE
ci: fixing broken job dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       from: ${{ github.workflow }}
   release:
     runs-on: ubuntu-latest
-    needs: call-ci-workflow
+    needs: call-test-workflow
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Summary

Changing the release job names to match in dependencies